### PR TITLE
Fix the inclusion of the autoloader

### DIFF
--- a/_tuts/dir-structure-composer-json-values.diff
+++ b/_tuts/dir-structure-composer-json-values.diff
@@ -939,7 +939,7 @@ index 5101ab8..4f987c3 100644
  use Symfony\Component\HttpFoundation\Request;
  
 -$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
-+$loader = require_once __DIR__.'/../app/autoload.php';
++$loader = require __DIR__.'/../app/autoload.php';
 +include_once __DIR__.'/../var/bootstrap.php.cache';
  
  // If your web server provides APC support for PHP applications, uncomment these
@@ -953,7 +953,7 @@ index 698c1d1..82257c1 100644
  }
  
 -$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
-+$loader = require_once __DIR__.'/../app/autoload.php';
++$loader = require __DIR__.'/../app/autoload.php';
  Debug::enable();
  
  $kernel = new AppKernel('dev', true);


### PR DESCRIPTION
require_once does not ensure that the loader returned by the file is returned to the code. This happens only on the first inclusion (otherwise the inclusion returns true).
To be sure to get the loader, require needs to be used instead.
